### PR TITLE
[#35] SpringSecurityAuditorAware 구현

### DIFF
--- a/src/main/java/com/example/outsourcingproject/domain/user/entity/User.java
+++ b/src/main/java/com/example/outsourcingproject/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.example.outsourcingproject.domain.user.entity;
 
-import com.example.outsourcingproject.global.entity.BaseEntity;
+import com.example.outsourcingproject.global.entity.SystemManagedEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+public class User extends SystemManagedEntity {
 
     @Id
     private Long id; // Auth와 동일한 PK

--- a/src/main/java/com/example/outsourcingproject/global/config/JpaConfig.java
+++ b/src/main/java/com/example/outsourcingproject/global/config/JpaConfig.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "springSecurityAuditorAware")
 public class JpaConfig {
 }

--- a/src/main/java/com/example/outsourcingproject/global/config/SpringSecurityAuditorAware.java
+++ b/src/main/java/com/example/outsourcingproject/global/config/SpringSecurityAuditorAware.java
@@ -1,0 +1,35 @@
+package com.example.outsourcingproject.global.config;
+
+import com.example.outsourcingproject.global.security.UserPrincipal;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class SpringSecurityAuditorAware implements AuditorAware<Long> {
+
+    @Override
+    @NonNull
+    public Optional<Long> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) {
+            return Optional.empty();
+        }
+
+        try {
+            UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+            return Optional.of(userPrincipal.getId());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/example/outsourcingproject/global/entity/SystemManagedEntity.java
+++ b/src/main/java/com/example/outsourcingproject/global/entity/SystemManagedEntity.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public class SystemManagedEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -24,14 +22,6 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "last_modified_by")
-    private Long lastModifiedBy;
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;

--- a/src/test/java/com/example/outsourcingproject/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/outsourcingproject/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,117 @@
+package com.example.outsourcingproject.domain.auth.service;
+
+import com.example.outsourcingproject.domain.auth.dto.request.SignupRequestDto;
+import com.example.outsourcingproject.domain.auth.dto.response.SignupResponseDto;
+import com.example.outsourcingproject.domain.auth.entity.Auth;
+import com.example.outsourcingproject.domain.auth.enums.UserRole;
+import com.example.outsourcingproject.domain.auth.event.UserRegisteredEvent;
+import com.example.outsourcingproject.domain.auth.repository.AuthRepository;
+import com.example.outsourcingproject.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private AuthRepository authRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
+
+    @Mock
+    private LoginAttemptService loginAttemptService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+                authRepository,
+                passwordEncoder,
+                jwtTokenProvider,
+                refreshTokenService,
+                tokenBlacklistService,
+                loginAttemptService,
+                eventPublisher
+        );
+    }
+
+    private void setId(Auth auth) {
+        try {
+            java.lang.reflect.Field idField = Auth.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(auth, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException("ID 설정 실패", e);
+        }
+    }
+
+    @DisplayName("회원가입 성공 테스트")
+    @Test
+    void signup_Success() {
+        // given
+        SignupRequestDto signupRequest = new SignupRequestDto(
+                "차준호",
+                "Juno",
+                "ckwnsgh@example.com",
+                "Password123!"
+        );
+
+        given(authRepository.existsByEmail(signupRequest.getEmail())).willReturn(false);
+        given(authRepository.existsByUsername(signupRequest.getUsername())).willReturn(false);
+        given(passwordEncoder.encode(signupRequest.getPassword())).willReturn("encodedPassword");
+
+        Auth savedAuth = new Auth(
+                signupRequest.getName(),
+                signupRequest.getUsername(),
+                signupRequest.getEmail(),
+                "encodedPassword",
+                UserRole.USER
+        );
+
+        setId(savedAuth);
+
+        given(authRepository.save(any(Auth.class))).willReturn(savedAuth);
+
+        // when
+        SignupResponseDto result = authService.signup(signupRequest);
+
+        // then
+        assertThat(result.getUsername()).isEqualTo(signupRequest.getUsername());
+        assertThat(result.getEmail()).isEqualTo(signupRequest.getEmail());
+
+        // 이벤트 발행 검증
+        ArgumentCaptor<UserRegisteredEvent> eventCaptor = ArgumentCaptor.forClass(UserRegisteredEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        UserRegisteredEvent publishedEvent = eventCaptor.getValue();
+        assertThat(publishedEvent.getUserId()).isEqualTo(1L);
+        assertThat(publishedEvent.getName()).isEqualTo(signupRequest.getName());
+        assertThat(publishedEvent.getEmail()).isEqualTo(signupRequest.getEmail());
+    }
+}


### PR DESCRIPTION
## 변경 사항
- BaseEntity를 상속받는 테이블에서 로그인된 사용자가 특정 값을 생성, 수정, 삭제 시에 추적이 가능하도록 userId가 각 컬럼에 대입됨
 