### PR TITLE
[#64] 태스크 수정 시 태스크가 생성되는 문제 수정

### DIFF
--- a/src/main/java/com/example/outsourcingproject/domain/task/entity/Task.java
+++ b/src/main/java/com/example/outsourcingproject/domain/task/entity/Task.java
@@ -58,4 +58,15 @@ public class Task extends BaseEntity {
         this.deadline = deadline;
         this.startedAt = startedAt;
     }
+
+    public void updateTask(String title, String description, Priority priority, User assignee, LocalDateTime deadline, LocalDateTime startedAt) {
+        this.title = title != null ? title : this.title;
+        this.description = description != null ? description : this.description;
+        this.priority = priority != null ? priority : this.priority;
+        this.assignee = assignee != null ? assignee : this.assignee;
+        this.deadline = deadline != null ? deadline : this.deadline;
+        this.startedAt = startedAt != null ? startedAt : this.startedAt;
+    }
+
+
 }

--- a/src/main/java/com/example/outsourcingproject/domain/task/service/TaskService.java
+++ b/src/main/java/com/example/outsourcingproject/domain/task/service/TaskService.java
@@ -116,27 +116,17 @@ public class TaskService {
                 .map(this::findUserName)
                 .orElse(task.getAssignee());
 
-        // 새 값이 있을 경우만 업데이트하기
-        String title = Optional.ofNullable(requestDto.getTitle()).orElse(task.getTitle());
-        String description = Optional.ofNullable(requestDto.getDescription()).orElse(task.getDescription());
-        Priority priority = Optional.ofNullable(requestDto.getPriority()).map(Priority::fromString).orElse(task.getPriority());
-        LocalDateTime deadline = Optional.ofNullable(requestDto.getDeadline()).orElse(task.getDeadline());
-        LocalDateTime startedAt = Optional.ofNullable(requestDto.getStartedAt()).orElse(task.getStartedAt());
-
-        Task updateTask = new Task(
-                title,
-                description,
-                priority,
+        task.updateTask(
+                requestDto.getTitle(),
+                requestDto.getDescription(),
+                requestDto.getPriority() != null ? Priority.fromString(requestDto.getPriority()) : null,
                 assignee,
-                task.getCreator(),
-                task.getStatus(),
-                deadline,
-                startedAt
-        );
+                requestDto.getDeadline(),
+                requestDto.getStartedAt());
 
-        taskRepository.save(updateTask);
+        taskRepository.save(task);
 
-        return TaskReadResponseDto.toDto(updateTask);
+        return TaskReadResponseDto.toDto(task);
     }
 
     // Task 상태 수정


### PR DESCRIPTION
## 이슈 내용
- 브랜치 병합 과정에서 태스크 수정 기능의 일부 코드가 변경되어 발생한 것으로 추정
- 이로 인해 taskI로 조회한 Task를 수정하는 것이 아니라 신규 Task 를 생성하는 이슈 확인

## 작업 내용
- Task 엔티티에 updateTask 메서드 생성 
  -> null 값일 경우 기존 값 유지, 새로운 값일 경우 저장
- TaskService > updateTask() 에서 요청 DTO 값을 Task의 updateTask() 메서드를 호출하여 전달 -> 새로운 값이 있을 경우 taskId로 조회한 Task 의 값이 수정되도록 구현