### PR TITLE
[#80] Docker 개발환경 구축 및 테스트 코드 에러 메시지 통일

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Git
+.git
+.gitignore
+
+# IDE
+.idea
+*.iws
+*.iml
+*.ipr
+.vscode
+
+# Build outputs
+build/
+target/
+!gradle/wrapper/gradle-wrapper.jar
+
+# Test reports
+**/build/reports/
+**/build/test-results/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+
+# Environment files
+.env
+.env.*
+!.env.example
+.env.local
+.env.*.local
+**/src/main/resources/properties/env.properties
+
+# Temporary files
+*.tmp
+*.temp
+
+# Documentation
+*.md
+docs/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# TaskFlow 환경 변수 설정
+# 이 파일을 .env로 복사한 후 실제 값으로 변경하세요
+
+# 데이터베이스 설정
+DB_URL=jdbc:mysql://mysql:3306/taskFlow?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+DB_USERNAME=taskflow_user
+DB_PASSWORD=your_secure_db_password_here
+MYSQL_ROOT_PASSWORD=your_secure_root_password_here
+
+# JWT 설정 - 반드시 새로운 시크릿키 생성!
+# 아래 명령어로 생성: openssl rand -base64 64
+JWT_SECRET_KEY=your_jwt_secret_key_here_minimum_64_characters_long_please_generate_new_one
+JWT_ACCESS_TOKEN_EXPIRATION=900000
+JWT_REFRESH_TOKEN_EXPIRATION=1209600000
+
+# 로깅 설정
+LOGGING_LEVEL_ROOT=INFO
+LOGGING_LEVEL_COM_EXAMPLE=DEBUG

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ application-local.properties
 
 ### env ###
 /src/main/resources/properties/env.properties
+.env
+.env.local
+.env.*.local
 
 /src/test/resources/
 **/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Multi-stage build for optimization
+FROM gradle:8.5-jdk17 AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# Gradle 설정 파일들 먼저 복사 (캐시 최적화)
+COPY build.gradle settings.gradle ./
+COPY gradle/ gradle/
+
+# 소스 코드 복사
+COPY src/ src/
+
+# 애플리케이션 빌드 (테스트 제외)
+RUN gradle clean build -x test --no-daemon
+
+# Runtime stage
+FROM amazoncorretto:17-alpine
+
+# 애플리케이션 실행을 위한 디렉토리 생성
+WORKDIR /app
+
+# 빌드된 JAR 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# 애플리케이션 실행을 위한 사용자 생성 (보안)
+RUN addgroup --system spring && adduser --system spring --ingroup spring
+USER spring:spring
+
+# 포트 노출
+EXPOSE 8080
+
+# 헬스체크 추가
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.8'
+
+services:
+  # MySQL 데이터베이스
+  mysql:
+    image: mysql:8.0
+    container_name: taskflow-mysql
+    restart: unless-stopped
+    ports:
+      - "3307:3306"  # 외부 3307 → 내부 3306
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: taskFlow
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./DDL.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    networks:
+      - taskflow-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  # Spring Boot 애플리케이션
+  taskflow-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: taskflow-backend
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      # 데이터베이스 연결 설정
+      DB_URL: ${DB_URL}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+
+      # JWT 설정
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
+      JWT_REFRESH_TOKEN_EXPIRATION: ${JWT_REFRESH_TOKEN_EXPIRATION}
+
+      # 로깅 설정
+      LOGGING_LEVEL_ROOT: INFO
+      LOGGING_LEVEL_COM_EXAMPLE: DEBUG
+
+      # Spring 프로파일
+      SPRING_PROFILES_ACTIVE: docker
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - taskflow-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/auth/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+networks:
+  taskflow-network:
+    driver: bridge
+
+volumes:
+  mysql_data:
+    driver: local

--- a/src/test/java/com/example/outsourcingproject/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/outsourcingproject/domain/auth/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.example.outsourcingproject.domain.auth.dto.response.SigninResponseDto
 import com.example.outsourcingproject.domain.auth.dto.response.SignupResponseDto;
 import com.example.outsourcingproject.domain.auth.entity.Auth;
 import com.example.outsourcingproject.domain.auth.entity.RefreshToken;
+import com.example.outsourcingproject.domain.auth.enums.AuthErrorMessage;
 import com.example.outsourcingproject.domain.auth.enums.UserRole;
 import com.example.outsourcingproject.domain.auth.event.UserRegisteredEvent;
 import com.example.outsourcingproject.domain.auth.event.UserWithdrawnEvent;
@@ -142,7 +143,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.signup(signupRequest))
                 .isInstanceOf(DuplicateEmailException.class)
-                .hasMessage("이미 존재하는 이메일입니다.");
+                .hasMessage(AuthErrorMessage.DUPLICATE_EMAIL.getMessage());
 
         verify(authRepository, never()).save(any(Auth.class));
         verify(eventPublisher, never()).publishEvent(any());
@@ -161,7 +162,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.signup(signupRequest))
                 .isInstanceOf(DuplicateEmailException.class)
-                .hasMessage("이미 존재하는 사용자명입니다.");
+                .hasMessage(AuthErrorMessage.DUPLICATE_USERNAME.getMessage());
 
         verify(authRepository, never()).save(any(Auth.class));
         verify(eventPublisher, never()).publishEvent(any());
@@ -202,7 +203,8 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.signin(signinRequest))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("잘못된 사용자명 또는 비밀번호입니다");
+                .hasMessage(AuthErrorMessage.INVALID_CREDENTIALS.getMessage());
+
 
         verify(loginAttemptService, never()).recordSuccessfulLogin(any());
     }
@@ -221,7 +223,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.signin(signinRequest))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("잘못된 사용자명 또는 비밀번호입니다");
+                .hasMessage(AuthErrorMessage.INVALID_CREDENTIALS.getMessage());
 
         verify(loginAttemptService).recordFailedAttempt(signinRequest.getUsername());
         verify(loginAttemptService, never()).recordSuccessfulLogin(any());
@@ -239,7 +241,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.signin(signinRequest))
                 .isInstanceOf(RateLimitException.class)
-                .hasMessage("로그인이 일시적으로 차단되었습니다.");
+                .hasMessage(AuthErrorMessage.ACCOUNT_BLOCKED.format(10L));
 
         verify(authRepository, never()).findActiveByUsername(any());
     }
@@ -283,7 +285,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.refreshToken(refreshTokenValue))
                 .isInstanceOf(UserNotFoundException.class)
-                .hasMessage("사용자를 찾을 수 없습니다.");
+                .hasMessage(AuthErrorMessage.USER_NOT_FOUND.getMessage());
     }
 
     @DisplayName("로그아웃 성공 테스트")
@@ -352,7 +354,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.withdraw(userId, password))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("사용자를 찾을 수 없습니다.");
+                .hasMessage(AuthErrorMessage.WITHDRAW_USER_NOT_FOUND.getMessage());
 
         verify(refreshTokenService, never()).deleteRefreshTokenByUserId(any());
         verify(eventPublisher, never()).publishEvent(any());
@@ -373,7 +375,7 @@ public class AuthServiceTest {
         // when and then
         assertThatThrownBy(() -> authService.withdraw(userId, wrongPassword))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("비밀번호가 일치하지 않습니다.");
+                .hasMessage(AuthErrorMessage.PASSWORD_MISMATCH.getMessage());
 
         verify(authRepository, never()).save(any());
         verify(refreshTokenService, never()).deleteRefreshTokenByUserId(any());

--- a/src/test/java/com/example/outsourcingproject/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/outsourcingproject/domain/auth/service/RefreshTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.outsourcingproject.domain.auth.service;
 
 import com.example.outsourcingproject.domain.auth.entity.RefreshToken;
+import com.example.outsourcingproject.domain.auth.enums.AuthErrorMessage;
 import com.example.outsourcingproject.domain.auth.exception.InvalidCredentialsException;
 import com.example.outsourcingproject.domain.auth.repository.RefreshTokenRepository;
 import com.example.outsourcingproject.global.security.JwtProperties;
@@ -82,7 +83,7 @@ public class RefreshTokenServiceTest {
         // when and then
         assertThatThrownBy(() -> refreshTokenService.validateRefreshToken(tokenValue))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("유효하지 않은 Refresh Token 입니다.");
+                .hasMessage(AuthErrorMessage.INVALID_REFRESH_TOKEN.getMessage());
     }
 
     @DisplayName("만료된 리프레시 토큰 검증 실패 테스트")
@@ -98,7 +99,7 @@ public class RefreshTokenServiceTest {
         // when and then
         assertThatThrownBy(() -> refreshTokenService.validateRefreshToken(tokenValue))
                 .isInstanceOf(InvalidCredentialsException.class)
-                .hasMessage("만료된 Refresh Token 입니다.");
+                .hasMessage(AuthErrorMessage.EXPIRED_REFRESH_TOKEN.getMessage());
     }
 
     @DisplayName("사용자별 리프레시 토큰 삭제 테스트")


### PR DESCRIPTION
- Docker 개발환경 설정
  * docker-compose.yml 추가
  * Dockerfile 생성
  * 개발용 환경변수 설정 (.env.example)
  * 포트 설정: MySQL(3306), Spring Boot(8080)

- 테스트 코드 에러 메시지 표준화
  * AuthServiceTest: AuthErrorMessage enum 메시지 사용으로 통일
  * RefreshTokenServiceTest: AuthErrorMessage enum 메시지 사용으로 통일
  * 테스트 실패 원인이었던 하드코딩된 에러 메시지를 enum 기반으로 수정
  * 총 8개 테스트 메서드의 예외 메시지 검증 로직 개선